### PR TITLE
chore: remove env_snippet artifact + bump v3.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [3.0.1] - 2026-06-28
+
+### Removed
+- **`env_snippet.txt`** — stray env fragment with a placeholder key pattern; secrets belong in
+  `.env.local` only (see `.env.example`). Sanitized in two steps to keep GitGuardian checks green.
+
+---
+
 ## [3.0.0] - 2026-06-27
 
 ### Added

--- a/env_snippet.txt
+++ b/env_snippet.txt
@@ -1,4 +1,2 @@
-# MINIMAX PRIME (The Brain)
-# Get your key from: https://platform.minimaxi.com/
-MINIMAX_API_KEY=your_sk_key_here
-MINIMAX_GROUP_ID=your_group_id_here_if_applicable
+# Deprecated — do not add secrets here.
+# Copy .env.example to .env.local and configure MINIMAX / other keys there.

--- a/env_snippet.txt
+++ b/env_snippet.txt
@@ -1,2 +1,0 @@
-# Deprecated — do not add secrets here.
-# Copy .env.example to .env.local and configure MINIMAX / other keys there.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "silhouette-llm",
   "private": true,
-  "version": "3.0.0",
+  "version": "3.0.1",
   "type": "module",
   "main": "electron.cjs",
   "repository": {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Post-merge cleanup **Phase 1** — remove the stray `env_snippet.txt` file (placeholder key fragment that never belonged in git) and bump patch version to **3.0.1**.

## Approach (careful / GitGuardian-aware)

Two-step commit history on the branch:
1. Sanitize file content (strip `sk`-key placeholder pattern)
2. Delete the file (already listed in `.gitignore`)

No application logic changed. Full quality gate run locally.

## Verification

- `npm run lint` — 0 errors
- `npm run typecheck` — pass
- `npm test` — 155/155 pass

## Note

If **GitGuardian** flags the removed placeholder line in commit 1, mark it as a false positive once in the GitGuardian dashboard (filepath exclusion for `env_snippet.txt`) — the value was never a real secret.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ecee961d-6378-46da-b7ea-347ec5b7d4e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ecee961d-6378-46da-b7ea-347ec5b7d4e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

